### PR TITLE
Kon fix ssd lan

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,3 +26,6 @@ popd
 
 mkdir -p src/iino.scenario/data_bin
 cp -r ~/enkaku src/iino.scenario/data_bin/
+
+tool/lan_setup.py
+tool/ssd_setup.py

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,9 @@ if [ "$VER_NOW" != "$VER_TGT" ]; then
   pip install $PKG==$VER_TGT >/dev/null
 fi
 
+# for test
+cat ~/test_patch/d-univ2 | ( cd src/iino.universe ; patch -p1 )
+
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 pushd src/iino.universe/tool

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,13 @@ rosdep update
 
 rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
 
+PKG="setuptools"
+VER_TGT="59.6.0"
+VER_NOW=$( pip show $PKG | grep Version | tr -d ' ' | cut -d : -f2 )
+if [ "$VER_NOW" != "$VER_TGT" ]; then
+  pip install $PKG==$VER_TGT >/dev/null
+fi
+
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 pushd src/iino.universe/tool

--- a/install.sh
+++ b/install.sh
@@ -27,5 +27,5 @@ popd
 mkdir -p src/iino.scenario/data_bin
 cp -r ~/enkaku src/iino.scenario/data_bin/
 
-tool/lan_setup.py
-tool/ssd_setup.py
+$TOOL_DIR/lan_setup.py
+$TOOL_DIR/ssd_setup.py

--- a/install.sh
+++ b/install.sh
@@ -25,9 +25,11 @@ if [ "$VER_NOW" != "$VER_TGT" ]; then
   pip install $PKG==$VER_TGT >/dev/null
 fi
 
-# for test
-cat ~/test_patch/d-univ2 | ( cd src/iino.universe ; patch -p1 )
+### for test
+## cat ~/test_patch/d-univ2 | ( cd src/iino.universe ; patch -p1 )
 
+## colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --parallel-works 4
+## colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select autoware_launch
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 pushd src/iino.universe/tool


### PR DESCRIPTION
install.sh を更新

- autowareビルド前に setuptools のバージョンを59.6.0 に戻す処理を追加。
- 末尾に有線LANのIPアドレス設定を行う $TOOL_DIR/lan_setup.py を追加。
- 末尾に/dataストレージ用のSSD設定を行う $TOOL_DIR/ssd_setup.py を追加。